### PR TITLE
Add 64-bit version for bare metal Rust on RPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ In 2018 Mozilla asked for creation of an embedded workgroup to help drive adopti
 -   [Robigalia](https://robigalia.org) IoT operating system in Rust running on secure seL4 microkernel.
 -   [Tock](https://www.tockos.org) An embedded operating system designed for running multiple concurrent, mutually distrustful applications on low-memory and low-power microcontrollers
 -   [intermezzOS](http://intermezzos.github.io) A small teaching operating system in Rust. A book with some explanations is also included.
--   [Raspberry Pi Bare Metal Programming with Rust](https://medium.com/@thiagopnts/raspberry-pi-bare-metal-programming-with-rust-a6f145e84024) A starter article on OSdev with Rust on RPi (cross-compiler setup and a very basic LED-blinking kernel).
+-   Raspberry Pi Bare Metal Programming with Rust
+    -   [32-bit Version (most Pi1 and Pi2 variants)](https://medium.com/@thiagopnts/raspberry-pi-bare-metal-programming-with-rust-a6f145e84024) A starter article on OSdev with Rust on RPi (cross-compiler setup and a very basic LED-blinking kernel).
+    -   [64-bit Version (Pi2 Model B v1.2 and all Pi3)](https://github.com/andre-richter/rust-raspi3-tutorial) A growing collection of tutorials, from simple booting to interfacing components like UARTs or random number generators; Features a painless cross-toolchain setup.
 -   [Fearless concurrency](http://blog.japaric.io/fearless-concurrency/) by @japaric — How to easily develop Rust programs for pretty much any ARM Cortex-M microcontroller with memory-safe concurrency.
 -   [RTFM v2](http://blog.japaric.io/rtfm-v2/) Real-Time For the Masses — Cortex-M programming framework for building concurrent applications.
 -   [cortex-m rtfm](https://github.com/japaric/cortex-m-rtfm) RTFM framework for ARM Cortex-M microcontrollers


### PR DESCRIPTION
- Add a link to a tutorial collection for bare metal Rust programming on 64-bit Raspberry PIs.
- Since a different tutorial for 32-bit versions already exists, categorize them under a common headline.

https://github.com/andre-richter/rust-raspi3-tutorial