### PR TITLE
Add link to WIP atsamd21 device and hal crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Register definition for microcontroller families. Usually generated using [`svd2
 
 - [`cortex-m`](https://github.com/japaric/cortex-m) Low level access to Cortex-M processors
 
+### Atmel / Microchip
+
+- [`atsamd21`](https://github.com/wez/atsamd21-rs) Peripheral access API for Atmel SAMD21 microcontrollers.  This git repo hosts both the device crate and the hal.
+
 ### Nordic
 
 - [`nrf51`](https://crates.io/crates/nrf51) Peripheral access API for nRF51 microcontrollers (generated using svd2rust) - ![crates.io](https://img.shields.io/crates/v/nrf51.svg)

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Register definition for microcontroller families. Usually generated using [`svd2
 
 - [`cortex-m`](https://github.com/japaric/cortex-m) Low level access to Cortex-M processors
 
-### Atmel / Microchip
+### Microchip
 
-- [`atsamd21`](https://github.com/wez/atsamd21-rs) Peripheral access API for Atmel SAMD21 microcontrollers.  This git repo hosts both the device crate and the hal.
+- [`atsamd21`](https://github.com/wez/atsamd21-rs) Peripheral access API for Microchip (formerly Atmel) SAMD21 microcontrollers.  This git repo hosts both the device crate and the hal.
 
 ### Nordic
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ Register definition for microcontroller families. Usually generated using [`svd2
 
 [svd2rust-kw]: https://crates.io/keywords/svd2rust
 
-### ARM
-
-- [`cortex-m`](https://github.com/japaric/cortex-m) Low level access to Cortex-M processors
-
 ### Microchip
 
 - [`atsamd21`](https://github.com/wez/atsamd21-rs) Peripheral access API for Microchip (formerly Atmel) SAMD21 microcontrollers.  This git repo hosts both the device crate and the hal.


### PR DESCRIPTION
These both live in the same repo, so I'm not sure if you'd prefer to break this out and link to the subdirs in that repo or just keep this one entry.

https://github.com/rust-lang-nursery/embedded-wg/issues/61 is the issue I opened with some background on this.