### PR TITLE
Add embedded-graphics crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,8 @@ Work in progress drivers. Help the authors make these crates awesome!
 - [bit_field](https://crates.io/crates/bit_field): manipulating bitfields and bitarrays - ![crates.io](https://img.shields.io/crates/v/bit_field.svg)
 - [heapless](https://crates.io/crates/heapless): provides `Vec`, `String`, `LinearMap`, `RingBuffer` backed by fixed-size buffers  - ![crates.io](https://img.shields.io/crates/v/heapless.svg)
 - [managed](https://crates.io/crates/managed): provides `ManagedSlice`, `ManagedMap` backed by either their std counterparts or fixed-size buffers for `#![no_std]`. - ![crates.io](https://img.shields.io/crates/v/managed.svg)
-- [smoltcp](https://github.com/m-labs/smoltcp): a small TCP/IP stack that runs without `alloc` 
+- [smoltcp](https://github.com/m-labs/smoltcp): a small TCP/IP stack that runs without `alloc`
+- [embedded-graphics](https://crates.io/crates/embedded-graphics): 2D drawing library for tiny displays - ![crates.io](https://img.shields.io/crates/v/embedded-graphics.svg)
 
 [no-std-category]: https://crates.io/categories/no-std
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 - [heapless](https://crates.io/crates/heapless): provides `Vec`, `String`, `LinearMap`, `RingBuffer` backed by fixed-size buffers  - ![crates.io](https://img.shields.io/crates/v/heapless.svg)
 - [managed](https://crates.io/crates/managed): provides `ManagedSlice`, `ManagedMap` backed by either their std counterparts or fixed-size buffers for `#![no_std]`. - ![crates.io](https://img.shields.io/crates/v/managed.svg)
 - [smoltcp](https://github.com/m-labs/smoltcp): a small TCP/IP stack that runs without `alloc`
-- [embedded-graphics](https://crates.io/crates/embedded-graphics): 2D drawing library for tiny displays - ![crates.io](https://img.shields.io/crates/v/embedded-graphics.svg)
+- [embedded-graphics](https://crates.io/crates/embedded-graphics): 2D drawing library for any size display - ![crates.io](https://img.shields.io/crates/v/embedded-graphics.svg)
 
 [no-std-category]: https://crates.io/categories/no-std
 


### PR DESCRIPTION
This adds the [embedded-graphics](https://github.com/jamwaffles/embedded-graphics) crate to the bottom of the no_std list.