### PR TITLE
add nalgebra

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 - [bit_field](https://crates.io/crates/bit_field): manipulating bitfields and bitarrays - ![crates.io](https://img.shields.io/crates/v/bit_field.svg)
 - [heapless](https://crates.io/crates/heapless): provides `Vec`, `String`, `LinearMap`, `RingBuffer` backed by fixed-size buffers  - ![crates.io](https://img.shields.io/crates/v/heapless.svg)
 - [managed](https://crates.io/crates/managed): provides `ManagedSlice`, `ManagedMap` backed by either their std counterparts or fixed-size buffers for `#![no_std]`. - ![crates.io](https://img.shields.io/crates/v/managed.svg)
+- [nalgebra](https://crates.io/crates/nalgebra): general-purpose and low-dimensional linear algebra library ![crates.io](https://img.shields.io/crates/v/nalgebra.svg)
 - [smoltcp](https://github.com/m-labs/smoltcp): a small TCP/IP stack that runs without `alloc`
 - [embedded-graphics](https://crates.io/crates/embedded-graphics): 2D drawing library for any size display - ![crates.io](https://img.shields.io/crates/v/embedded-graphics.svg)
 - [scroll](https://crates.io/crates/scroll): extensible and endian-aware Read/Write traits for generic containers - ![crates.io](https://img.shields.io/crates/v/scroll.svg)


### PR DESCRIPTION
[nalgebra](https://crates.io/crates/nalgebra): general-purpose and low-dimensional linear algebra library
official support added as of [0.15.0](https://www.patreon.com/posts/nalgebra-v0-15-0-19049120)