### PR TITLE
Add MicroRust to book section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ In 2018 Rust community has created an embedded workgroup to help drive adoption 
 -   [cortex-m rtfm](https://github.com/japaric/cortex-m-rtfm) RTFM framework for ARM Cortex-M microcontrollers
 -   [msp430 rtfm](https://github.com/japaric/msp430-rtfm) RTFM framework for MSP430 MCUs
 -   [FreeRTOS.rs](https://github.com/hashmismatch/freertos.rs) Rust interface for the FreeRTOS API
+-   [MicroRust](https://droogmic.github.io/microrust/) Introductory book for embedded development in Rust on the micro:bit.
 
 ## Tools
 


### PR DESCRIPTION
MicroRust is a book similar to Discovery, but written for the micro:bit.

Closes #52
