### PR TITLE
Add url to crates.io and badge for eeprom24x crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 - [OneWire] - 1wire - OneWire protocol implementation with drivers for devices such as [DS18B20](https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf) - ![crates.io](https://img.shields.io/crates/v/onewire.svg)
 - [SSD1322] - SPI - Graphical OLED display controller - ![crates.io](https://img.shields.io/crates/v/ssd1322.svg)
 - [GridEYE] - I2C - Rust driver for Grid-EYE / Panasonic AMG88(33)
-- [EEPROM24x] - I2C - 24x series serial EEPROM driver
+- [EEPROM24x] - I2C - 24x series serial EEPROM driver ![crates.io](https://img.shields.io/crates/v/eeprom24x.svg)
 - [DS1307] - I2C - Real-time clock driver - ![crates.io](https://img.shields.io/crates/v/ds1307.svg)
 
 [MFRC522]: https://github.com/japaric/mfrc522
@@ -371,7 +371,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 [OneWire]: https://crates.io/crates/onewire
 [SSD1322]: https://crates.io/crates/ssd1322
 [GridEYE]: https://github.com/uwearzt/grideye
-[EEPROM24x]: https://github.com/eldruin/eeprom24x-rs
+[EEPROM24x]: https://crates.io/crates/eeprom24x
 [DS1307]: https://crates.io/crates/ds1307
 
 ## no-std crates


### PR DESCRIPTION
I just published the feature-complete driver for 24x series EEPROMs to crates.io