### PR TITLE
Add WIP driver for various waveshare epaper modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 - [EEPROM24x] - I2C - 24x series serial EEPROM driver ![crates.io](https://img.shields.io/crates/v/eeprom24x.svg)
 - [DS1307] - I2C - Real-time clock driver - ![crates.io](https://img.shields.io/crates/v/ds1307.svg)
 - [PCF857x] - I2C - I/O expanders: PCF8574, PCF8574A, PCF8575 ![crates.io](https://img.shields.io/crates/v/pcf857x.svg)
+- [eink-waveshare] - SPI - driver for E-Paper Modules from Waveshare
 
 [MFRC522]: https://github.com/japaric/mfrc522
 [MPU9250]: https://github.com/japaric/mpu9250
@@ -375,6 +376,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 [EEPROM24x]: https://crates.io/crates/eeprom24x
 [DS1307]: https://crates.io/crates/ds1307
 [PCF857x]: https://crates.io/crates/pcf857x
+[eink-waveshare]: https://crates.io/crates/eink_waveshare_rs
 
 ## no-std crates
 


### PR DESCRIPTION
I finally got the time to release this driver on crates.io so I thought i would also be a good time to maybe mention it here.

It only has tested supported for the 4.2" Display at the moment.