### PR TITLE
Add physical computing rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ In 2018 Rust community has created an embedded workgroup to help drive adoption 
 -   [msp430 rtfm](https://github.com/japaric/msp430-rtfm) RTFM framework for MSP430 MCUs
 -   [FreeRTOS.rs](https://github.com/hashmismatch/freertos.rs) Rust interface for the FreeRTOS API
 -   [MicroRust](https://droogmic.github.io/microrust/) Introductory book for embedded development in Rust on the micro:bit.
+-   [Physical Computing With Rust](https://rahul-thakoor.github.io/physical-computing-rust/) A (WIP) guide to physical computing with Rust on the Raspberry Pi.
 
 ## Tools
 


### PR DESCRIPTION
Add link to the Physical Computing with Rust guide. It is an adapted version of the Physical Computing with Python by the Raspberry Pi Foundation.

