### PR TITLE
Add WIP crate for TCA9548A and PCA9548A I2C switches/multiplexers

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 - [PCF857x] - I2C - I/O expanders: PCF8574, PCF8574A, PCF8575 ![crates.io](https://img.shields.io/crates/v/pcf857x.svg)
 - [eink-waveshare] - SPI - driver for E-Paper Modules from Waveshare
 - [BlueNRG] - SPI - driver for BlueNRG-MS Bluetooth module. ![crates.io](https://img.shields.io/crates/v/bluenrg.svg)
+- [xCA9548A] - I2C - I2C switches/multiplexers: TCA9548A, PCA9548A
 
 [MFRC522]: https://github.com/japaric/mfrc522
 [MPU9250]: https://github.com/japaric/mpu9250
@@ -388,6 +389,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 [PCF857x]: https://crates.io/crates/pcf857x
 [eink-waveshare]: https://crates.io/crates/eink_waveshare_rs
 [BlueNRG]: https://crates.io/crates/bluenrg
+[xCA9548A]: https://github.com/eldruin/xca9548a-rs
 
 ## no-std crates
 


### PR DESCRIPTION
Hi,
I have a WIP crate for the TCA9548A and PCA9548A I2C switches/multiplexers.