### PR TITLE
Add embedded hal mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ In 2018 Rust community has created an embedded workgroup to help drive adoption 
 -   [xargo](https://github.com/japaric/xargo) Rust package manager with support for non-default std libraries — build rust runtime for your own embedded system.
 -   [svd2rust](https://github.com/japaric/svd2rust) Generate Rust structs with register mappings from SVD files.
 -   [μtest](https://github.com/japaric/utest) unit testing for microcontrollers and other no-std systems.
--   [`embedded-hal-mock`] Mock implementation of `embedded-hal` traits for testing without accessing real hardware. - ![crates.io](https://img.shields.io/crates/v/embedded-hal-mock.svg)
+-   [embedded-hal-mock] Mock implementation of `embedded-hal` traits for testing without accessing real hardware. - ![crates.io](https://img.shields.io/crates/v/embedded-hal-mock.svg)
 -   [bindgen](https://crates.io/crates/bindgen) Automatically generates Rust FFI bindings to C and C++ libraries. - ![crates.io](https://img.shields.io/crates/v/bindgen.svg)
 -   [cortex-m semihosting](https://github.com/japaric/cortex-m-semihosting) Semihosting for ARM Cortex-M processors
 -   [bobbin-cli](https://github.com/bobbin-rs/bobbin-cli) A Rust command line tool to simplify embedded development and deployment.
 -   [cargo-fel4](https://github.com/maindotrs/cargo-fel4) A Cargo subcommand for working with feL4 projects. - ![crates.io](https://img.shields.io/crates/v/cargo-fel4.svg)
 
-[`embedded-hal-mock`]: https://crates.io/crates/embedded-hal-mock
+[embedded-hal-mock]: https://crates.io/crates/embedded-hal-mock
 
 ## Device crates
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ Implementations of [`embedded-hal`] for microcontroller families and systems run
 
 ### Testing
 
-- [`embedded-hal-mock`] mock implementation of `embedded-hal` traits for testing without accessing hardware. - ![crates.io](https://img.shields.io/crates/v/embedded-hal-mock.svg)
+- [`embedded-hal-mock`] - ![crates.io](https://img.shields.io/crates/v/embedded-hal-mock.svg)
+  - Mock implementation of `embedded-hal` traits for testing without accessing real hardware.
 
 [`embedded-hal-mock`]: https://crates.io/crates/embedded-hal-mock
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,13 @@ In 2018 Rust community has created an embedded workgroup to help drive adoption 
 -   [xargo](https://github.com/japaric/xargo) Rust package manager with support for non-default std libraries — build rust runtime for your own embedded system.
 -   [svd2rust](https://github.com/japaric/svd2rust) Generate Rust structs with register mappings from SVD files.
 -   [μtest](https://github.com/japaric/utest) unit testing for microcontrollers and other no-std systems.
+-   [`embedded-hal-mock`] Mock implementation of `embedded-hal` traits for testing without accessing real hardware. - ![crates.io](https://img.shields.io/crates/v/embedded-hal-mock.svg)
 -   [bindgen](https://crates.io/crates/bindgen) Automatically generates Rust FFI bindings to C and C++ libraries. - ![crates.io](https://img.shields.io/crates/v/bindgen.svg)
 -   [cortex-m semihosting](https://github.com/japaric/cortex-m-semihosting) Semihosting for ARM Cortex-M processors
 -   [bobbin-cli](https://github.com/bobbin-rs/bobbin-cli) A Rust command line tool to simplify embedded development and deployment.
 -   [cargo-fel4](https://github.com/maindotrs/cargo-fel4) A Cargo subcommand for working with feL4 projects. - ![crates.io](https://img.shields.io/crates/v/cargo-fel4.svg)
+
+[`embedded-hal-mock`]: https://crates.io/crates/embedded-hal-mock
 
 ## Device crates
 
@@ -145,13 +148,6 @@ Implementations of [`embedded-hal`] for microcontroller families and systems run
 - [`linux-embedded-hal`] for embedded Linux systems like the Raspberry Pi. - ![crates.io](https://img.shields.io/crates/v/linux-embedded-hal.svg)
 
 [`linux-embedded-hal`]: https://crates.io/crates/linux-embedded-hal
-
-### Testing
-
-- [`embedded-hal-mock`] - ![crates.io](https://img.shields.io/crates/v/embedded-hal-mock.svg)
-  - Mock implementation of `embedded-hal` traits for testing without accessing real hardware.
-
-[`embedded-hal-mock`]: https://crates.io/crates/embedded-hal-mock
 
 ### Nordic
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Implementations of [`embedded-hal`] for microcontroller families and systems run
 
 [`linux-embedded-hal`]: https://crates.io/crates/linux-embedded-hal
 
+### Testing
+
+- [`embedded-hal-mock`] mock implementation of `embedded-hal` traits for testing without accessing hardware. - ![crates.io](https://img.shields.io/crates/v/embedded-hal-mock.svg)
+
+[`embedded-hal-mock`]: https://crates.io/crates/embedded-hal-mock
+
 ### Nordic
 
 - [`nrf51-hal`](https://crates.io/crates/nrf51-hal) - ![crates.io](https://img.shields.io/crates/v/nrf51-hal.svg)


### PR DESCRIPTION
I find this crate extremely useful when writing device crates and think it should definitely be included here.
I was not sure where to put it, though. I put it after the OS section, and before all the vendor-specific HALs but I am open to put it in any other place.
@dbrgn :)