### PR TITLE
Add TMP006 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ have achieved the "released" status (published on crates.io + documentation / sh
 14. [keypad] - GPIO - Keypad matrix circuits - [Intro post][14] - ![crates.io](https://img.shields.io/crates/v/keypad.svg)
 15. [BlueNRG] - SPI - driver for BlueNRG-MS Bluetooth module - [Intro post][15] ![crates.io](https://img.shields.io/crates/v/bluenrg.svg)
 16. [shared-bus] - I2C - utility driver for sharing a bus between multiple devices - [Intro post][16] ![crates.io](https://img.shields.io/crates/v/shared-bus.svg)
-
+17. [TMP006] - I2C - Contact-less infrared (IR) thermopile temperature sensor driver - [Intro post][17] ![crates.io](https://img.shields.io/crates/v/tmp006.svg)
 
 [L3GD20]: https://crates.io/crates/l3gd20
 [LSM303DLHC]: https://crates.io/crates/lsm303dlhc
@@ -339,6 +339,9 @@ have achieved the "released" status (published on crates.io + documentation / sh
 
 [shared-bus]: https://github.com/Rahix/shared-bus
 [16]: https://blog.rahix.de/001-shared-bus/
+
+[TMP006]: https://crates.io/crates/tmp006
+[17]: https://blog.eldruin.com/tmp006-contact-less-infrared-ir-thermopile-driver-in-rust/
 
 *NOTE* You may be able to find even more driver crates by searching for the [`embedded-hal-driver`]
 keyword on crates.io!


### PR DESCRIPTION
I wrote a driver for the TMP006 contact-less IR thermopile. This time including blog post.