### PR TITLE
OS: add embedded-hal traits implementation for FTDI chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ Implementations of [`embedded-hal`] for microcontroller families and systems run
 ### OS
 
 - [`linux-embedded-hal`] for embedded Linux systems like the Raspberry Pi. - ![crates.io](https://img.shields.io/crates/v/linux-embedded-hal.svg)
+- [`ftdi-embedded-hal`] for FTDI FTx232H chips connected to Linux systems via USB
 
 [`linux-embedded-hal`]: https://crates.io/crates/linux-embedded-hal
+[`ftdi-embedded-hal`]: https://github.com/geomatsi/ftdi-embedded-hal
 
 ### Nordic
 


### PR DESCRIPTION
Add link to implementation of embedded-hal traits for FTDI FTx232H chips
connected to Linux systems via USB.

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>