### PR TITLE
Use subitems for MSP430 quickstart crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Peripheral Access Crates were also called Device Crates.
 ### MSP430
 
 -   [`msp430g2553`](https://github.com/japaric/msp430g2553) Peripheral access API for MSP430G2553 microcontrollers (generated using svd2rust)
-    - [rust on msp](https://github.com/japaric/rust_on_msp) Simple blinking LED example that runs on MSP430.
     - [msp430 quickstart](https://github.com/japaric/msp430-quickstart) some examples for msp430
 
 ## HAL implementation crates

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ Peripheral Access Crates were also called Device Crates.
 ### MSP430
 
 -   [`msp430g2553`](https://github.com/japaric/msp430g2553) Peripheral access API for MSP430G2553 microcontrollers (generated using svd2rust)
--   [rust on msp](https://github.com/japaric/rust_on_msp) Simple blinking LED example that runs on MSP430.
--   [msp430 quickstart](https://github.com/japaric/msp430-quickstart) some examples for msp430
+    - [rust on msp](https://github.com/japaric/rust_on_msp) Simple blinking LED example that runs on MSP430.
+    - [msp430 quickstart](https://github.com/japaric/msp430-quickstart) some examples for msp430
 
 ## HAL implementation crates
 


### PR DESCRIPTION
Technically, they are not Peripheral Access Crates