### PR TITLE
Added light-cli crates.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 
 Work in progress crates. Help the authors make these crates awesome!
 
-- [light-cli](https://github.com/rudihorn/light-cli): a lightweight heapless cli interface
+- [light-cli](https://github.com/rudihorn/light-cli): a lightweight heapless cli interface ![crates.io](https://img.shields.io/crates/v/light_cli.svg)
 - [OxCC](https://github.com/jonlamb-gh/oxcc): A port of Open Source Car Control written in Rust
 
 [no-std-category]: https://crates.io/categories/no-std


### PR DESCRIPTION
I've now updated this project so it compiles with the new `stm32f1xx-hal` crate and have also pushed this to `crates.io`. As such I have added a badge here. 