### PR TITLE
README.md: Add ADXL343 driver info

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ have achieved the "released" status (published on crates.io + documentation / sh
 18. [BNO055] - I2C - Bosch Sensortec BNO055 9-axis IMU driver - [Intro post][18] ![crates.io](https://img.shields.io/crates/v/bno055.svg)
 19. [SH1106] - I2C - Monochrome OLED display controller - [Intro post][19] ![crates.io](https://img.shields.io/crates/v/sh1106.svg)
 20. [embedded-sdmmc] - SPI - SD/MMC Card Driver with MS-DOS Partition and FAT16/FAT32 support - [Intro post][20] ![crates.io](https://img.shields.io/crates/v/embedded-sdmmc.svg)
+21. [ADXL343] - I2C - 3-axis accelerometer - ![crates.io](https://img.shields.io/crates/v/adxl343.svg)
 
 [L3GD20]: https://crates.io/crates/l3gd20
 [LSM303DLHC]: https://crates.io/crates/lsm303dlhc
@@ -373,6 +374,8 @@ have achieved the "released" status (published on crates.io + documentation / sh
 
 [embedded-sdmmc]: https://crates.io/crates/embedded-sdmmc
 [20]: https://www.reddit.com/r/rust/comments/ascvls/introducing_embeddedsdmmc_a_purerust_no_std_sd/
+
+[ADXL343]: https://crates.io/crates/adxl343
 
 *NOTE* You may be able to find even more driver crates by searching for the [`embedded-hal-driver`]
 keyword on crates.io!


### PR DESCRIPTION
I wrote a driver for the ADXL343 in support of the [Adafruit NeoTrellis M4](https://github.com/rust-embedded/wg/issues/286):

https://crates.io/crates/adxl343

Will make some videos for it in a bit... seems you also want an intro blog post?