### PR TITLE
Add GD32VF103 chip support crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ The [`stm32-rs`](https://github.com/stm32-rs/stm32-rs) project has peripheral ac
 
 - [`ambiq-apollo3-pac`](https://crates.io/crates/ambiq-apollo3-pac) Peripheral access API for Ambiq Apollo3 microcontrollers (generated using svd2rust)
 
+### GigaDevice
+
+- [`gd32vf103-pac`](https://https://github.com/riscv-rust/gd32vf103-pac) Peripheral access API for GD32VF103 RISC-V microcontrollers (generated using svd2rust) - ![crates.io](https://img.shields.io/crates/v/gd32vf103-pac.svg)
+
 ## HAL implementation crates
 
 Implementations of [`embedded-hal`] for microcontroller families and systems running some OS. - ![crates.io](https://img.shields.io/crates/v/embedded-hal.svg)
@@ -281,6 +285,10 @@ Also check the list of [STMicroelectronics board support crates][stm-bsc]!
 ### XMC
 
 - [`xmc1100-hal`](https://github.com/david-sawatzke/xmc1100-hal) - ![crates.io](https://img.shields.io/crates/v/xmc1100-hal.svg)
+
+### GigaDevice
+
+- [`gd32vf103-hal`](https://https://github.com/luojia65/gd32vf103-hal) - ![crates.io](https://img.shields.io/crates/v/gd32vf103-hal.svg)
 
 ## Architecture support crates
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ Also check the list of [STMicroelectronics board support crates][stm-bsc]!
 
 ### GigaDevice
 
-- [`gd32vf103-hal`](https://github.com/luojia65/gd32vf103-hal) - ![crates.io](https://img.shields.io/crates/v/gd32vf103-hal.svg)
+- [`gd32vf103-hal`](https://github.com/luojia65/gd32vf103-hal) - ![crates.io](https://img.shields.io/crates/v/gd32vf103-hal.svg) 
+  - (WIP) Hardware abstract layer (HAL) for the GD32VF103 RISC-V microcontroller 
 
 ## Architecture support crates
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The [`stm32-rs`](https://github.com/stm32-rs/stm32-rs) project has peripheral ac
 
 ### GigaDevice
 
-- [`gd32vf103-pac`](https://https://github.com/riscv-rust/gd32vf103-pac) Peripheral access API for GD32VF103 RISC-V microcontrollers (generated using svd2rust) - ![crates.io](https://img.shields.io/crates/v/gd32vf103-pac.svg)
+- [`gd32vf103-pac`](https://github.com/riscv-rust/gd32vf103-pac) Peripheral access API for GD32VF103 RISC-V microcontrollers (generated using svd2rust) - ![crates.io](https://img.shields.io/crates/v/gd32vf103-pac.svg)
 
 ## HAL implementation crates
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Also check the list of [STMicroelectronics board support crates][stm-bsc]!
 
 ### GigaDevice
 
-- [`gd32vf103-hal`](https://https://github.com/luojia65/gd32vf103-hal) - ![crates.io](https://img.shields.io/crates/v/gd32vf103-hal.svg)
+- [`gd32vf103-hal`](https://github.com/luojia65/gd32vf103-hal) - ![crates.io](https://img.shields.io/crates/v/gd32vf103-hal.svg)
 
 ## Architecture support crates
 


### PR DESCRIPTION
This pull request adds PAC and HAL libraries for embedded Rust on GD32VF103.
GD32VF103 is a microcontroller chip produced by GigaDevice Semiconductor Inc. with one Bumblebee RISC-V's RV32IMAC core @108 MHz, up to 128 KiB of Flash and 32 KiB of SRAM. 
This chip will be in market on late September this year along with its development board Longan Nano (by Sipeed); it's Rust support is under rapid development to provide appropriate ecosystem.