### PR TITLE
Add a link to the `stm32f7xx-hal` crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ Also check the list of [STMicroelectronics board support crates][stm-bsc]!
 - [`stm32f4xx-hal`](https://crates.io/crates/stm32f4xx-hal) - ![crates.io](https://img.shields.io/crates/v/stm32f4xx-hal.svg)
    - Generic HAL implementation for all MCUs of the stm32f4 series
 
+- [`stm32f7xx-hal`](https://crates.io/crates/stm32f7xx-hal) - ![crates.io](https://img.shields.io/crates/v/stm32f7xx-hal.svg)
+   - Generic HAL implementation for all MCUs of the stm32f7 series
+
 - [`stm32l0xx-hal`](https://crates.io/crates/stm32l0xx-hal) - ![crates.io](https://img.shields.io/crates/v/stm32l0xx-hal.svg)
    - HAL implementation for the the STMicro STM32L0xx family of microcontrollers
 


### PR DESCRIPTION
Just recently released the `stm32-rs/stm32f7xx-hal` crate to crates.io and it seems like a good fit for this list!