### PR TITLE
Add a link to the HZ Grow R502 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 - [ST7735-lcd] - SPI - An embedded-graphics compatible driver for the popular lcd family from Sitronix ![crates.io](https://img.shields.io/crates/v/st7735-lcd.svg)
 - [spi-memory] - SPI - A generic driver for various SPI Flash and EEPROM chips - ![crates.io](https://img.shields.io/crates/v/spi-memory.svg)
 - [st7032i] - I2C - Dot Matrix LCD Controller driver (Sitronix ST7032i or similar). - ![crates.io](https://img.shields.io/crates/v/st7032i.svg)
+- [hzgrow-r502] - UART capacitive fingerprint reader - ![crates.io](https://img.shields.io/crates/v/hzgrow-r502.svg)
 
 [MFRC522]: https://github.com/japaric/mfrc522
 [motor-driver]: https://github.com/japaric/motor-driver
@@ -699,6 +700,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 [ST7735-lcd]: https://crates.io/crates/st7735-lcd
 [spi-memory]: https://github.com/jonas-schievink/spi-memory/
 [st7032i]: https://github.com/dotcypress/st7032i
+[hzgrow-r502]: https://crates.io/crates/hzgrow-r502
 
 ## no-std crates
 


### PR DESCRIPTION
The driver is for the HZ Grow R502 capacitive fingerprint reader module. I hope it's of use to someone. It's not quite awesome yet as not all functionality of the R502 is implemented and the code is in need of review by someone who actually knows what they're doing.