### PR TITLE
Point stmf32f3 users to currently maintained crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Also check the list of [STMicroelectronics board support crates][stm-bsc]!
 [Blue pill]: http://wiki.stm32duino.com/index.php?title=Blue_Pill
 [Nucleo-F103RB]: http://www.st.com/en/evaluation-tools/nucleo-f103rb.html
 
-- [`stm32f30x-hal`](https://crates.io/crates/stm32f30x-hal) - ![crates.io](https://img.shields.io/crates/v/stm32f30x-hal.svg)
+- [`stm32f3xx-hal`](https://crates.io/crates/stm32f3xx-hal) - ![crates.io](https://img.shields.io/crates/v/stm32f3xx-hal.svg)
 
 - [`stm32f4xx-hal`](https://crates.io/crates/stm32f4xx-hal) - ![crates.io](https://img.shields.io/crates/v/stm32f4xx-hal.svg)
    - Generic HAL implementation for all MCUs of the stm32f4 series


### PR DESCRIPTION
Per https://github.com/stm32-rs/stm32f3xx-hal/issues/48 and https://github.com/japaric/stm32f30x-hal/issues/36, point stm32f3 users to the community supported stm32f3xx crate, instead of japaric's unmaintained stm32f30x crate.