### PR TITLE
Add 1bitsy board support crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ Crates tailored for specific boards.
 [STM32F4DISCOVERY]: https://www.st.com/en/evaluation-tools/stm32f4discovery.html
 [STM32F429DISCOVERY]: https://www.st.com/en/evaluation-tools/32f429idiscovery.html
 
+### 1BitSquared
+
+- [`onebitsy`](https://crates.io/crates/onebitsy) - Board support crate for the [1bitsy] STM32F4-based board - ![crates.io](https://img.shields.io/crates/v/onebitsy.svg)
+
+[1bitsy]: https://1bitsy.org/
+
 ### Adafruit
 
 - [`metro_m4`](https://crates.io/crates/metro_m4) - ![crates.io](https://img.shields.io/crates/v/metro_m4.svg)


### PR DESCRIPTION
I've been working on a board support crate for the [1bitsy](https://1bitsy.org/) board, which is based on an STM32F415 MCU. The board is relatively simple, so there's only a few things to abstract:

* one LED
* one Button
* a 25MHz high-frequency external clock source