### PR TITLE
Remove reference to emosenkis/esp8266-hal

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,6 @@ Also check the list of [STMicroelectronics board support crates][stm-bsc]!
 
 ### Espressif
 
-- [`esp8266-hal`](https://github.com/emosenkis/esp8266-hal) ![crates.io](https://img.shields.io/crates/v/esp8266-hal.svg) (not supported by rustc, so must be built with [mrustc](https://github.com/thepowersgang/mrustc), typically via the [esp-rs](https://github.com/emosenkis/esp-rs) build script)
 - [`rust-xtensa`](https://github.com/MabezDev/rust-xtensa)
   - rust fork enables projects to be built for the ESP32 and ESP8266. ([quick start repo](https://github.com/MabezDev/xtensa-rust-quickstart)).
 


### PR DESCRIPTION
It has been deprecated in favor of work towards directly supporting Xtensa in rustc which is already mentioned here.