### PR TITLE
Add link to Arduino Nano 33 IoT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Crates tailored for specific boards.
 - [`avr-hal`](https://github.com/Rahix/avr-hal) - Board support crate for several AVR-based boards including the Arduino Uno and the Arduino Leonardo
 - [`arduino_mkrvidor4000`](https://crates.io/crates/arduino_mkrvidor4000) - Board support for the [MKR Vidor board](https://store.arduino.cc/usa/mkr-vidor-4000) ![crates.io](https://img.shields.io/crates/v/arduino_mkrvidor4000.svg)
 - [`arduino_mkrzero`](https://crates.io/crates/arduino_mkrzero) - Board support for the [mkrzero board](https://store.arduino.cc/arduino-mkrzero) ![crates.io](https://img.shields.io/crates/v/arduino_mkrzero.svg)
+- [`arduino_nano33iot`](https://crates.io/crates/arduino_nano33iot) - Board support for the [Arduino Nano 33 IoT](https://store.arduino.cc/usa/nano-33-iot) ![crates.io](https://img.shields.io/crates/v/arduino_nano33iot.svg)
 
 ### Nordic
 


### PR DESCRIPTION
I just finished adding this crate, so I figured I'd add a link, in the same section as boards in the same repo