### PR TITLE
Add sram23x

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ have achieved the "released" status (published on crates.io + documentation / sh
 1. [shared-bus] - I2C - utility driver for sharing a bus between multiple devices - [Intro post][16] ![crates.io](https://img.shields.io/crates/v/shared-bus.svg)
 1. [shift-register-driver] - GPIO - Shift register - [Intro blog post][10] - ![crates.io](https://img.shields.io/crates/v/shift-register-driver.svg)
 1. [Si4703] - I2C - FM radio turner (receiver) driver  - [Intro blog post][31] - ![crates.io](https://img.shields.io/crates/v/si4703.svg)
+1. [SRAM23x] - SPI - Microchip 23x series serial SRAM/NVSRAM driver - [Intro blog post][51] - ![crates.io](https://img.shields.io/crates/v/sram23x.svg)
 1. [SSD1306] - I2C/SPI - OLED display controller - [Intro blog post][8] - ![crates.io](https://img.shields.io/crates/v/ssd1306.svg)
 1. [Sx127x] - SPI - Long Range Low Power Sub GHz (Gfsk, LoRa) RF Transceiver - [Intro blog post][34] - ![crates.io](https://img.shields.io/crates/v/radio-sx127x.svg)
 1. [Sx128x] - SPI - Long range, low power 2.4 GHz (Gfsk, Flrc, LoRa) RF Transceiver - [Intro blog post][35] - ![crates.io](https://img.shields.io/crates/v/radio-sx128x.svg)
@@ -620,6 +621,7 @@ have achieved the "released" status (published on crates.io + documentation / sh
 [48]: https://github.com/michaelbeaumont/dht-sensor
 [49]: https://blog.eldruin.com/ccs811-indoor-air-quality-sensor-driver-in-rust/
 [50]: https://nitschinger.at/Rusty-PID-Porting-the-TSic-sensor-from-C-to-Rust/
+[51]: https://blog.a1w.ca/p/rust-embedded-driver-microchip-23x-sram
 
 [AD983x]: https://crates.io/crates/ad983x
 [adafruit-alphanum4]: https://crates.io/crates/adafruit-alphanum4
@@ -657,6 +659,7 @@ have achieved the "released" status (published on crates.io + documentation / sh
 [shared-bus]: https://github.com/Rahix/shared-bus
 [shift-register-driver]: https://crates.io/crates/shift-register-driver
 [Si4703]: https://crates.io/crates/si4703
+[SRAM23x]: https://crates.io/crates/sram23x
 [SSD1306]: https://crates.io/crates/ssd1306
 [Sx127x]: https://crates.io/crates/radio-sx127x
 [Sx128x]: https://crates.io/crates/radio-sx128x


### PR DESCRIPTION
Hello,

I wrote a driver for [Microchip 23x series SRAM/NVSRAM](https://github.com/aw/sram23x) chips. I also published an [intro blog post](https://blog.a1w.ca/p/rust-embedded-driver-microchip-23x-sram).

Thanks.