### PR TITLE
README.md: remove e.ziclean-cube firmware project

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,7 +969,6 @@ Work in progress crates. Help the authors make these crates awesome!
 ## Firmware projects
 
 - [anne-key](https://github.com/ah-/anne-key): Alternate keyboard firmware for the Obins ANNE Pro
-- [e.ziclean cube vacuum cleaner](https://github.com/geomatsi/e.ziclean-cube): Experiments with open firmware for e.ziclean cube vacuum cleaner
 
 ## Old books, blogs and training materials
 


### PR DESCRIPTION
It was fun to do some reverse-engineering of the board  and experiment with its peripherals using Rust. However I haven't been working on this project for a while. So it is time to remove the stale e.ziclean-cube firmware project.

Regards,
Sergey