### PR TITLE
Add embedded-hal-compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ In 2018 the Rust community created an embedded working group to help drive adopt
     - [flip-link](https://github.com/knurling-rs/flip-link), a linker wrapper that provides stack overflow protection without an MMU by flipping the standard memory layout of ARM Cortex-M programs
     - [app-template](https://github.com/knurling-rs/app-template), a `cargo-generate` powered project template for quickly setting up new projects using the Knurling Tools.
     - [defmt-test](https://github.com/knurling-rs/defmt-test), an embedded test harness that lets you write and run unit tests as if you were using the built-in `#[test]` attribute, but will run on an embedded target
+    - [embedded-hal-compat](https://github.com/ryankurte/embedded-hal-compat), a compatibility layer to provide interoperability between `v0.2.x` and `v1.x.x` hal implementations and drivers
 
 [embedded-hal-mock]: https://crates.io/crates/embedded-hal-mock
 


### PR DESCRIPTION
I build a little forward/reverse compatibility layer to run drivers across different HAL versions, there's probably plenty of room for improvement but already finding it pretty useful.