### PR TITLE
Add SKEAZN642 PAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Peripheral Access Crates were also called Device Crates.
 - [`lpc845-pac`](https://crates.io/crates/lpc845-pac) - ![crates.io](https://img.shields.io/crates/v/lpc845-pac.svg)
 - [`mkw41z`](https://crates.io/crates/mkw41z) - ![crates.io](https://img.shields.io/crates/v/mkw41z.svg)
 - [`imxrt-ral`](https://github.com/imxrt-rs/imxrt-rs) Register access layer for i.MX RT series. -  ![crates.io](https://img.shields.io/crates/v/imxrt-ral.svg)
+- [`SKEAZN642`](https://crates.io/crates/SKEAZN642) Peripheral access API for KEA64 family microcontrollers (generated using svd2rust) - ![crates.io](https://img.shields.io/crates/v/SKEAZN642.svg)
 
 
 ### SiFive


### PR DESCRIPTION
PAC to support NXP KEA64 series (KEAZN16, 32, and 64) of MCUs.
https://github.com/wcpannell/SKEAZN642