### PR TITLE
Update link to ftdi-embedded-hal

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Implementations of [`embedded-hal`] for microcontroller families and systems run
 - [`linux-embedded-hal`] for embedded Linux systems like the Raspberry Pi. - ![crates.io](https://img.shields.io/crates/v/linux-embedded-hal.svg)
 
 [`bitbang-hal`]: https://crates.io/crates/bitbang-hal
-[`ftdi-embedded-hal`]: https://github.com/geomatsi/ftdi-embedded-hal
+[`ftdi-embedded-hal`]: https://crates.io/crates/ftdi-embedded-hal
 [`linux-embedded-hal`]: https://crates.io/crates/linux-embedded-hal
 
 ### Microchip


### PR DESCRIPTION
Update link to implementation of embedded-hal traits for FTDI FTx232H chips. New version is published on crates.io. This version unifies two previous implementations: [ftd2xx-embedded-hal](https://github.com/newAM/ftd2xx-embedded-hal) based on proprietary libftd2xx library and [ftdi-embedded-hal](https://github.com/geomatsi/ftdi-embedded-hal-archive) based on open source libftdi library. New version Implements generic backend support to allow using different low level FTDI libraries.