### PR TITLE
Vorago PAC & BSP and MAX116xx 10 bit ADC driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 1. [MAG3110] - I2C - Magnetometer
 1. [MAX17048/9] - I2C - LiPo Fuel gauge, battery monitoring IC - ![crates.io](https://img.shields.io/crates/v/max17048.svg)
 1. [MAX170xx] - I2C - LiPo Fuel gauge, battery monitoring ICs compatible with MAX17043/4, MAX17048/9, MAX17058/9.
+1. [MAX116xx-10bit] - SPI - Driver for the MAX11619-MAX11621, MAX11624 and MAX11625 10-bit ADCs - ![crates.io](https://img.shields.io/crates/v/max116xx-10bit.svg)
 1. [MAX3010x] - I2C - Pulse oximeter and heart-rate sensor. ATM Compatible with MAX30102. -![crates.io](https://img.shields.io/crates/v/max3010x.svg)
 1. [MAX31855] - SPI - Thermocouple digital converter -![crates.io](https://img.shields.io/crates/v/max31855.svg)
 1. [MAX31865] - SPI - RTD to Digital converter - ![crates.io](https://img.shields.io/crates/v/max31865.svg)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This project is developed and maintained by the [Resources team][team].
     * [STMicroelectronics](#stmicroelectronics-2)
     * [Texas Instruments](#texas-instruments-2)
     * [Teensy](#teensy)
+    * [Vorago](#vorago-2)
     * [Special Purpose](#special-purpose)
 * [Component abstraction crates](#component-abstraction-crates)
 * [Driver crates](#driver-crates)
@@ -273,6 +274,7 @@ Peripheral access crates for the different XMC4xxx families of microcontrollers
 ### Vorago
 
 - [`va108xx`](https://egit.irs.uni-stuttgart.de/rust/va108xx) - ![crates.io](https://img.shields.io/crates/v/va108xx.svg)
+- [`va416xx`](https://egit.irs.uni-stuttgart.de/rust/va416xx) - ![crates.io](https://img.shields.io/crates/v/va416xx.svg)
 
 ## HAL implementation crates
 
@@ -533,6 +535,10 @@ Crates tailored for specific boards.
 
 ### Teensy
 - [`teensy4-rs`](https://github.com/mciantyre/teensy4-rs) Board Support create for the [Teensy 4.0]
+
+### Vorago
+
+- [`vorago-reb1`](https://egit.irs.uni-stuttgart.de/rust/vorago-reb1) - ![crates.io](https://img.shields.io/crates/v/vorago-reb1.svg)
 
 ### Texas Instruments
 

--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 [MAG3110]: https://github.com/therealprof/mag3110
 [MAX17048/9]: https://crates.io/crates/max17048
 [MAX170xx]: https://github.com/eldruin/max170xx-rs
+[MAX116xx-10bit]: https://egit.irs.uni-stuttgart.de/rust/max116xx-10bit
 [MAX3010x]: https://crates.io/crates/max3010x
 [MAX31855]: https://github.com/cs2dsb/max31855.rs
 [MAX31865]: https://crates.io/crates/max31865


### PR DESCRIPTION
Adds three crates

- PAC for the Vorago VA416xx family of MCUs
- BSP for the Vorago REB1 developmemt board

Also adds a new device crate for the MAX116xx 10-bit ADC. Actually, I wasn't sure whether to add the device driver to the primary list or to the WIP list. There is not blog post (yet) and I was not sure whether this is a fixed requirement.
Some core features are supported which should be useful for the most common use-cases,  but of course there are some features that could still be added. If you think that this crate is ready for an official release, I could try to provide a blog post on something like Medium (or whatever platform you recommend)