### PR TITLE
Update readme.md with additional training material

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ In 2018 the Rust community created an embedded working group to help drive adopt
 -   [Ferrous Systems' Embedded Rust on Espressif](https://espressif-trainings.ferrous-systems.com/) - Training Material for learning to use Embedded Rust with the Espressif ESP32-C3.
 -   [DSP on STM32F407G-DISC1](https://github.com/jacobrosenthal/dsp-discoveryf4-rust/) Unofficial oxidization of the [Digital Signal Processing using Arm Cortex-M based Microcontrollers: Theory and Practice](https://www.amazon.com/Digital-Signal-Processing-Cortex-M-Microcontrollers/dp/1911531166) book. The book isn't necessary to enjoy the examples and learn a functional DSP Rust coding style.
 -   [Building a sailing starter board with Rust (RTIC)](https://gill.net.in/posts/stm32-pcb-sailing-and-rust/) A step by step story/guide to build STM32 based PCB and program it with rust for fun and games.
+-   [STM32F4xx with Embedded Rust at the HAL](https://apollolabsblog.hashnode.dev/series/stm32f4-embedded-rust-hal) A blog containing a series of tutorials demonstrating the use of several peripherals through simple examples leveraging the stm32f4xx-hal crate.
 -   [Embedded Rust programming playlist](https://www.youtube.com/playlist?list=PLP_X41VhYn5X6Wwjnm0bRwI3n2pdaszxU) Various livestreams with Embedded Rust live coding
 
 [Ferrous Systems]: https://ferrous-systems.com


### PR DESCRIPTION
I added a blog resource to the list that could be valuable to learners interested in learning HAL topics. I personally found it hard to navigate the different HALs when starting out based on the existing resources. I created the added blog in the hope to help newcomers that could be in the same position I was in. It's a blog I update on weekly basis with a new topic relevant to embedded Rust.  This is the link https://apollolabsblog.hashnode.dev/series/stm32f4-embedded-rust-hal 

On a side note, I had attempted to submit a pull request before though I think I did something wrong where it didn't make it through somehow.