### PR TITLE
Add sega-controller driver to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,7 @@ Otherwise please add it to the [WIP section](#WIP) below.
 [pwm-pca9685]: https://crates.io/crates/pwm-pca9685
 [rainbow-hat-rs]: https://crates.io/crates/rainbow-hat-rs
 [rotary-encoder-hal]: https://crates.io/crates/rotary-encoder-hal
+[sega-controller]: https://crates.io/crates/sega-controller
 [SGP30]: https://crates.io/crates/sgp30
 [SH1106]: https://crates.io/crates/sh1106
 [shared-bus]: https://github.com/Rahix/shared-bus

--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ Otherwise please add it to the [WIP section](#WIP) below.
 1. [pwm-pca9685] - I2C - 16-channel, 12-bit PWM/Servo/LED controller - [Intro blog post][32] - ![crates.io](https://img.shields.io/crates/v/pwm-pca9685.svg)
 1. [rainbow-hat-rs] - I2C/SPI/GPIO - Pimoroni Rainbow HAT driver for Raspberry Pi - [github][57] - ![crates.io](https://img.shields.io/crates/v/rainbow-hat-rs.svg)
 1. [rotary-encoder-hal] - GPIO - A rotary encoder driver using `embedded-hal` - [Intro blog post][28] - ![crates.io](https://img.shields.io/crates/v/rotary-encoder-hal.svg)
+1. [sega-controller] - GPIO - Sega controller input - [github][66] - ![crates.io](https://img.shields.io/crates/v/sega-controller.svg)
 1. [SGP30] - I2C - Gas sensor - [Intro blog post][6] - ![crates.io](https://img.shields.io/crates/v/sgp30.svg)
 1. [SH1106] - I2C - Monochrome OLED display controller - [Intro post][19] ![crates.io](https://img.shields.io/crates/v/sh1106.svg)
 1. [shared-bus] - I2C - utility driver for sharing a bus between multiple devices - [Intro post][16] ![crates.io](https://img.shields.io/crates/v/shared-bus.svg)
@@ -832,6 +833,7 @@ Otherwise please add it to the [WIP section](#WIP) below.
 [63]: https://blog.kiranshila.com/blog/pac_rust_driver.md
 [64]: https://github.com/Finomnis/st7565
 [65]: https://github.com/dlkj/usbd-human-interface-device
+[66]: https://github.com/UnderLogic/sega-controller
 
 [AD983x]: https://crates.io/crates/ad983x
 [adafruit-alphanum4]: https://crates.io/crates/adafruit-alphanum4


### PR DESCRIPTION
This PR adds the [`sega-controller`](https://github.com/UnderLogic/sega-controller) driver to the list of embedded-hal driver projects

I am the maintainer of this repo under my company.