### PR TITLE
Add switch-hal

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,8 @@ devices which go beyond what is available in [`embedded-hal`]:
 - [`atat`](https://github.com/BlackbirdHQ/atat): Abstraction crate to ease writting AT based driver crates - ![crates.io](https://img.shields.io/crates/v/atat.svg)
 - [`embedded-nal`](https://github.com/rust-embedded-community/embedded-nal): An Embedded Network Abstraction Layer - ![crates.io](https://img.shields.io/crates/v/embedded-nal.svg)
 - [`embedded-storage`](https://github.com/rust-embedded-community/embedded-storage): An Embedded Storage Abstraction Layer
+- [`switch-hal`](https://github.com/rubberduck203/switch-hal): An "on"/"off" abstraction for input and output switches - ![crates.io](https://img.shields.io/crates/v/switch-hal.svg)
+
 
 ## Driver crates
 


### PR DESCRIPTION
The switch-hal crate just extends embedded-hal by a bit (hah!) -- but I find it very useful, for it provides clean "on"/"off" semantics for what is otherwise merely "high"/"low", and thus dependent on the actual wiring (both LEDs and buttons are just as easy to wire either way).

It's not used a lot ([crates assume active-low](https://github.com/jamesmunns/blinq/issues/4) instead), but I hope that this changes once it is more visible through here.