### PR TITLE
Fix link to a RTIC v1 book

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ In 2018 the Rust community created an embedded working group to help drive adopt
 
 ### Real-time tools
 
--   [RTIC v1.0](https://rtic.rs/1.0/book/en/) Real-Time Interrupt-driven Concurrency — A concurrency framework for building real time systems:
+-   [RTIC v1.0](https://rtic.rs/1/book/en/) Real-Time Interrupt-driven Concurrency — A concurrency framework for building real time systems:
     -   [cortex-m rtic](https://github.com/rtic-rs/cortex-m-rtic) RTIC framework for ARM Cortex-M microcontrollers
     -   [msp430 rtfm](https://github.com/japaric/msp430-rtfm) RTFM framework for MSP430 MCUs
 


### PR DESCRIPTION
Current link leads to 404