### PR TITLE
Add BillMock to Firmware Project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1279,7 +1279,7 @@ Work in progress crates. Help the authors make these crates awesome!
 - [Booster](https://github.com/quartiq/booster): Firmware for an RF power amplifier, including telemetry via MQTT and run-time configuration
 - [Thermostat EEM](https://github.com/quartiq/thermostat-eem): Firmware for a multi-channel temperature controller used in physics experiments
 - [Card/IO ECG](https://github.com/card-io-ecg/card-io-fw): Firmware for a business-card sized ECG device with Wifi connectivity
-
+- [BillMcok](https://github.com/pmnxis/billmock-app-rs): Firmware for credit card terminal add-on hardware to install on Korean arcade machines
 
 ## Old books, blogs and training materials
 


### PR DESCRIPTION
Add my BillMock project (https://github.com/pmnxis/billmock-app-rs, detail description : http://billmock.pmnxis.net/) on firmware project list.

BillMock is Korean credit card terminal add-on board to use for arcade machines.
This project is a commercial and mass-production project, however making a proof of concept that rust embedded is usable for actual embedded production under the open-source state.
