### PR TITLE
pac: Add StarFive JH71xx PAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This project is developed and maintained by the [Resources team][team].
     - [Raspberry Pi Silicon](#raspberry-pi-silicon)
     - [SiFive](#sifive)
     - [Silicon Labs](#silicon-labs)
+    - [StarFive](#starfive)
     - [STMicroelectronics](#stmicroelectronics)
     - [Texas Instruments](#texas-instruments)
     - [MSP430](#msp430)
@@ -271,6 +272,15 @@ The [`efm32-rs`](https://github.com/efm32-rs) project has peripheral access APIs
 - [`efm32tg11b-pac`](https://crates.io/crates/efm32tg11b-pac) - ![crates.io](https://img.shields.io/crates/v/efm32tg11b-pac)
 - [`efm32wg-pac`](https://crates.io/crates/efm32wg-pac) - ![crates.io](https://img.shields.io/crates/v/efm32wg-pac)
 - [`efm32zg-pac`](https://crates.io/crates/efm32zg-pac) - ![crates.io](https://img.shields.io/crates/v/efm32zg-pac)
+
+### StarFive
+
+- [`j71xx-pac`](https://github.com/rmsyn/jh71xx-pac) - svd2rust generated interface to StarFive [JH71xx](https://www.starfivetech.com/en/site/soc) MCUs - ![crates.io](https://img.shields.io/crates/v/jh71xx-pac.svg)
+
+Currently, the two VisionFive2 board revisions (v1.2a and v1.3b) are supported:
+
+- [`jh7110-vf2-12a-pac`](https://crates.io/crates/jh7110-vf2-12a-pac) - ![crates.io](https://img.shields.io/crates/v/jh7110-vf2-12a-pac)
+- [`jh7110-vf2-13b-pac`](https://crates.io/crates/jh7110-vf2-13b-pac) - ![crates.io](https://img.shields.io/crates/v/jh7110-vf2-13b-pac)
 
 ### STMicroelectronics
 


### PR DESCRIPTION
Adds information for the [`jh71xx-pac`](https://github.com/rmsyn/jh71xx-pac) that supports the JH71xx SoCs from StarFive.