### PR TITLE
Add rmk firmware project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1285,7 +1285,7 @@ Work in progress crates. Help the authors make these crates awesome!
 
 ## Firmware projects
 
-- [rmk](https://github.com/HaoboGu/rmk): Mechanical keyboard firmware for stm32/rp2040, with dynamic keymap/vial/eeprom support, written in Rust
+- [rmk](https://github.com/HaoboGu/rmk): Mechanical keyboard firmware for stm32/rp2040, supports vial/dynamic keymap/eeprom, written in Rust
 - [anne-key](https://github.com/ah-/anne-key): Alternate keyboard firmware for the Obins ANNE Pro
 - [μLA](https://github.com/dotcypress/ula): Micro Logic Analyzer for RP2040
 - [air-gradient-pro-rs](https://github.com/jonlamb-gh/air-gradient-pro-rs): Bootloader, firmware and CLI tools for the AirGradient PRO

--- a/README.md
+++ b/README.md
@@ -1285,6 +1285,7 @@ Work in progress crates. Help the authors make these crates awesome!
 
 ## Firmware projects
 
+- [rmk](https://github.com/HaoboGu/rmk): Mechanical keyboard firmware for stm32/rp2040, with dynamic keymap/vial/eeprom support, written in Rust
 - [anne-key](https://github.com/ah-/anne-key): Alternate keyboard firmware for the Obins ANNE Pro
 - [μLA](https://github.com/dotcypress/ula): Micro Logic Analyzer for RP2040
 - [air-gradient-pro-rs](https://github.com/jonlamb-gh/air-gradient-pro-rs): Bootloader, firmware and CLI tools for the AirGradient PRO


### PR DESCRIPTION
Add [rmk firmware](https://github.com/HaoboGu/rmk) to readme. Rmk is a keyboard firmware which is built on `embedded-hal` and `rtic`. It has been tested on stm32h7 mcu and rp2040. 

Rmk supports vial, which makes users update their keymap dynamically. 

Users can make their own keyboard firmware using rmk as well.