### PR TITLE
jh71xx: clean up `jh71xx-pac` info and add JH71xx HAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,7 @@ The [`efm32-rs`](https://github.com/efm32-rs) project has peripheral access APIs
 
 ### StarFive
 
-- [`j71xx-pac`](https://github.com/rmsyn/jh71xx-pac) - svd2rust generated interface to StarFive [JH71xx](https://www.starfivetech.com/en/site/soc) MCUs - ![crates.io](https://img.shields.io/crates/v/jh71xx-pac.svg)
-
-Currently, the two VisionFive2 board revisions (v1.2a and v1.3b) are supported:
-
-- [`jh7110-vf2-12a-pac`](https://crates.io/crates/jh7110-vf2-12a-pac) - ![crates.io](https://img.shields.io/crates/v/jh7110-vf2-12a-pac)
-- [`jh7110-vf2-13b-pac`](https://crates.io/crates/jh7110-vf2-13b-pac) - ![crates.io](https://img.shields.io/crates/v/jh7110-vf2-13b-pac)
+- [`j71xx-pac`](https://crates.io/crates/jh71xx-pac) - svd2rust generated interface to StarFive [JH71xx](https://www.starfivetech.com/en/site/soc) MCUs - ![crates.io](https://img.shields.io/crates/v/jh71xx-pac.svg)
 
 ### STMicroelectronics
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This project is developed and maintained by the [Resources team][team].
     - [GigaDevice](#gigadevice-1)
     - [Vorago](#vorago-1)
     - [Renesas](#renesas-1)
+    - [StarFive](#starfive-1)
   - [Architecture support crates](#architecture-support-crates)
     - [ARM](#arm)
     - [RISC-V](#risc-v)
@@ -520,6 +521,10 @@ Also check the list of [STMicroelectronics board support crates][stm-bsc]!
 
 ### Renesas
 - [`da14531-hal`](https://crates.io/crates/da14531-hal) HAL crate for DA14531 Ultra-Low Power BT 5.1 System-on-Chip - ![crates.io](https://img.shields.io/crates/v/da14531-hal.svg)
+
+### StarFive
+
+- [`j71xx-hal`](https://crates.io/crates/jh71xx-hal) - HAL crate for StarFive [JH71xx](https://www.starfivetech.com/en/site/soc) MCUs - ![crates.io](https://img.shields.io/crates/v/jh71xx-hal.svg)
 
 ## Architecture support crates
 


### PR DESCRIPTION
Cleans up library information about `jh71xx-pac`, and adds an entry for the `jh71xx-hal` HAL crate.