### PR TITLE
Add embedded-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,6 +1218,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 1. [crossbus](https://github.com/hominee/crossbus): A Platform-Less, Runtime-Less Actor Computing Model.
 1. [ector](https://github.com/drogue-iot/ector): An async actor framework for embedded, based on embassy.
 1. [embassy]: A set of embedded async tools to make async/await a first-class option for embedded development
+1. [embedded-cli](https://crates.io/crates/embedded-cli): CLI library with autocompletion, subcommands, options, help and history support. ![crates.io](https://img.shields.io/crates/v/embedded-cli.svg)
 1. [embedded-crc-macros](https://crates.io/crates/embedded-crc-macros): Macros implementing portable CRC algorithms and build-time lookup table generation. ![crates.io](https://img.shields.io/crates/v/embedded-crc-macros.svg)
 1. [embedded-update](https://github.com/drogue-iot/embedded-update): Pluggable firmware update protocol for embedded devices.
 1. [embedded-tls](https://github.com/drogue-iot/embedded-tls): A TLS 1.3 implementation that runs in a no-std environment.


### PR DESCRIPTION
I would like to propose `embedded-cli` to the `no-std` list. It allows you to build CLIs that have autocompletion, subcommands, options, help and history. Crate page has a demo gif with example that runs on Arduino Nano showcasing all features.