### PR TITLE
Add micropb crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1267,7 +1267,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 1. [lorawan-device](https://github.com/lora-rs/lora-rs/tree/main/lorawan-device): A LoRaWAN MAC implementation supporting both event-driven and async mode.
 1. [managed](https://crates.io/crates/managed): provides `ManagedSlice`, `ManagedMap` backed by either their std counterparts or fixed-size buffers for `#![no_std]`. - ![crates.io](https://img.shields.io/crates/v/managed.svg)
 1. [menu]: A basic command-line interface library. Has nested menus and basic help functionality. ![crates.io](https://img.shields.io/crates/v/menu.svg)
-1. [micropb](https://github.com/YuhanLiin/micropb): Rust Protobuf library targetting embedded systems and no_std environments without an allocator.
+1. [micropb](https://crates.io/crates/micropb): Rust Protobuf library targetting embedded systems and no_std environments without an allocator. - ![crates.io](https://img.shields.io/crates/v/micropb.svg)
 1. [mqtt-sn](https://crates.io/crates/mqtt-sn): Implementation of the MQTT-SN protocol - ![crates.io](https://img.shields.io/crates/v/mqtt-sn.svg)
 1. [microfft](https://crates.io/crates/microfft): Embedded-friendly (`no_std`, no-`alloc`) fast fourier transforms - ![crates.io](https://img.shields.io/crates/v/microfft.svg)
 1. [micromath](https://github.com/NeoBirth/micromath): Embedded Rust math library featuring fast, safe floating point approximations for common arithmetic operations, 2D and 3D vector types, and statistical analysis - ![crates.io](https://img.shields.io/crates/v/micromath.svg)

--- a/README.md
+++ b/README.md
@@ -1267,6 +1267,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 1. [lorawan-device](https://github.com/lora-rs/lora-rs/tree/main/lorawan-device): A LoRaWAN MAC implementation supporting both event-driven and async mode.
 1. [managed](https://crates.io/crates/managed): provides `ManagedSlice`, `ManagedMap` backed by either their std counterparts or fixed-size buffers for `#![no_std]`. - ![crates.io](https://img.shields.io/crates/v/managed.svg)
 1. [menu]: A basic command-line interface library. Has nested menus and basic help functionality. ![crates.io](https://img.shields.io/crates/v/menu.svg)
+1. [micropb](https://github.com/YuhanLiin/micropb): Rust Protobuf library targetting embedded systems and no_std environments without an allocator.
 1. [mqtt-sn](https://crates.io/crates/mqtt-sn): Implementation of the MQTT-SN protocol - ![crates.io](https://img.shields.io/crates/v/mqtt-sn.svg)
 1. [microfft](https://crates.io/crates/microfft): Embedded-friendly (`no_std`, no-`alloc`) fast fourier transforms - ![crates.io](https://img.shields.io/crates/v/microfft.svg)
 1. [micromath](https://github.com/NeoBirth/micromath): Embedded Rust math library featuring fast, safe floating point approximations for common arithmetic operations, 2D and 3D vector types, and statistical analysis - ![crates.io](https://img.shields.io/crates/v/micromath.svg)


### PR DESCRIPTION
I've created a new Rust Protobuf library specifically aimed at embedded environments without an allocator, called [micropb](https://github.com/YuhanLiin/micropb). I felt that this was a missing niche in the Rust ecosystem, so I decided to create it. Now that it's been released, I'd like to add it to this repo.