### PR TITLE
Add information about Rust on Zephyr

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ specifically endorsed or reviewed for accuracy or quality by the Embedded Workin
 - [RIOT-OS](https://doc.riot-os.org/using-rust.html) directly supports applications written in Rust, both in terms of build system integration and by having safe and idiomatic wrappers.
 - [Tock](https://www.tockos.org) An embedded operating system designed for running multiple concurrent, mutually distrustful applications on low-memory and low-power microcontrollers
 - [Hubris](https://github.com/oxidecomputer/hubris) A real-time operating system built by Oxide Computer to run the Service Controller processor in the mainboards of their rack-mount servers.
+- [Zephyr](https://docs.zephyrproject.org/latest/develop/languages/rust/index.html) An embedded RTOS, written in C, with support for writing applications in Rust.
 
 ### Real-time tools
 


### PR DESCRIPTION
As of Zephyr 4.1, The Zephyr RTOS includes Rust support directly.

The Zephyr project: https://zephyrproject.org/
Rust support repo: https://github.com/zephyrproject-rtos/zephyr-lang-rust/