### PR TITLE
Add rumbac

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ specifically endorsed or reviewed for accuracy or quality by the Embedded Workin
 - [embedded-hal-compat](https://github.com/ryankurte/embedded-hal-compat), a compatibility layer to provide interoperability between `v0.2.x` and `v1.x.x` hal implementations and drivers
 - [Embassy start](https://github.com/titanclass/embassy-start) is a GitHub repo template for setting up async embedded Rust projects that use [Embassy](https://github.com/embassy-rs/embassy). This particular template targets nRF hardware and networking using the Uarte for the purposes of illustration only.
 - [svd-generator](https://codeberg.org/weathered-steel/svd-generator) CLI tool to parse flattened device tree files, and create a SVD file. - [![crates.io](https://img.shields.io/crates/v/svd-generator.svg)](https://crates.io/crates/svd-generator)
+- [rumbac](https://github.com/akavel/rumbac) is a simple CLI flasher for _Arduino Nano 33 BLE Rev2 / Sense Rev2_ boards, using the SAM-BA protocol to talk with the Arduino-provided bootloader, porting just enough of the `bossac` tool to Rust
 
 [embedded-hal-mock]: https://crates.io/crates/embedded-hal-mock
 


### PR DESCRIPTION
a simple CLI flasher for _Arduino Nano 33 BLE Rev2 / Sense Rev2_ boards, using the SAM-BA protocol to talk with the Arduino-provided bootloader, porting just enough of the `bossac` tool to Rust