### PR TITLE
Add derive-mmio

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ specifically endorsed or reviewed for accuracy or quality by the Embedded Workin
 - [probe-rs](https://github.com/probe-rs/probe-rs): a modern, embedded debugging toolkit, written in Rust
 - [Knurling Tools](https://knurling.ferrous-systems.com/tools/) are developed by [Ferrous Systems] to ease the development process for building, debugging, and testing embedded Rust systems. These tools include:
   - [defmt](https://github.com/knurling-rs/defmt): a highly efficient logging framework that targets resource-constrained devices, like microcontrollers.
+  - [derive-mmio](https://github.com/knurling-rs/derive-mmio): Creating MMIO-friendly APIs for embedded peripherals.
   - [flip-link](https://github.com/knurling-rs/flip-link), a linker wrapper that provides stack overflow protection without an MMU by flipping the standard memory layout of ARM Cortex-M programs
   - [app-template](https://github.com/knurling-rs/app-template), a `cargo-generate` powered project template for quickly setting up new projects using the Knurling Tools.
   - [defmt-test](https://github.com/knurling-rs/defmt-test), an embedded test harness that lets you write and run unit tests as if you were using the built-in `#[test]` attribute, but will run on an embedded target


### PR DESCRIPTION
This is an amazing tool. I used it for:

1. Creating a whole PAC/HAL: https://github.com/us-irs/zynq7000-rs/
2. Creating drivers for FPGA softcores: https://egit.irs.uni-stuttgart.de/rust/axi-uartlite and https://egit.irs.uni-stuttgart.de/rust/axi-uart16550
3. Writing a shared peripheral crate for 2 different CPU families: https://github.com/us-irs/vorago-shared-periphs which have a lot of identical peripherals.