### PR TITLE
Add willamhou/hypervisor (no_std ARM64 bare-metal hypervisor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1437,7 +1437,7 @@ There are many ways to handle panics in embedded devices, these crates provide h
 - [BillMock](https://github.com/pmnxis/billmock-app-rs): Firmware for credit card terminal add-on hardware to install on Korean arcade machines
 - [LuLuu](https://github.com/fu5ha/luluu): Firmware for a custom RP2040-based display controller that streams animated images from a microSD card to a small LCD display.
 - [prinThor](https://github.com/cbruiz/printhor): 3DPrinter/CNC/Engraver firmware framework powered by rust embassy for stm32 families and rp2040.
-- [hypervisor](https://github.com/willamhou/hypervisor): Bare-metal ARM64 Type-1 hypervisor in `no_std` Rust (single dependency: `fdt`). Runs at EL2, boots Linux with 4 vCPUs, virtio-blk/net, FF-A v1.1 SPMC at S-EL2. Targets QEMU virt machine.
+- [🤖 hypervisor](https://github.com/willamhou/hypervisor): Bare-metal ARM64 Type-1 hypervisor in `no_std` Rust (single dependency: `fdt`). Runs at EL2, boots Linux with 4 vCPUs, virtio-blk/net, FF-A v1.1 SPMC at S-EL2. Targets QEMU virt machine (no real hardware tested yet).
 
 ## Old books, blogs, and training materials
 

--- a/README.md
+++ b/README.md
@@ -1437,6 +1437,7 @@ There are many ways to handle panics in embedded devices, these crates provide h
 - [BillMock](https://github.com/pmnxis/billmock-app-rs): Firmware for credit card terminal add-on hardware to install on Korean arcade machines
 - [LuLuu](https://github.com/fu5ha/luluu): Firmware for a custom RP2040-based display controller that streams animated images from a microSD card to a small LCD display.
 - [prinThor](https://github.com/cbruiz/printhor): 3DPrinter/CNC/Engraver firmware framework powered by rust embassy for stm32 families and rp2040.
+- [hypervisor](https://github.com/willamhou/hypervisor): Bare-metal ARM64 Type-1 hypervisor in `no_std` Rust (single dependency: `fdt`). Runs at EL2, boots Linux with 4 vCPUs, virtio-blk/net, FF-A v1.1 SPMC at S-EL2. Targets QEMU virt machine.
 
 ## Old books, blogs, and training materials
 


### PR DESCRIPTION
## Summary

Adds [willamhou/hypervisor](https://github.com/willamhou/hypervisor) to the **Firmware projects** section.

**What it is**: A bare-metal ARM64 Type-1 hypervisor written in `no_std` Rust with a single runtime dependency (`fdt` crate). Runs at EL2 on QEMU virt machine, boots Linux 6.12.12 to BusyBox shell with 4 vCPUs, virtio-blk storage, and virtio-net networking.

**Key features**:
- `no_std`, no heap allocator crate — custom bump allocator, zero external runtime dependencies beyond `fdt`
- ARM64 EL2 bare-metal: Stage-2 page tables, GICv3 trap-and-emulate, PSCI, preemptive scheduling
- FF-A v1.1 Secure Partition Manager Core (SPMC) at S-EL2 with TF-A boot chain
- Multi-VM support with VMID-tagged TLBs, L2 virtual switch
- 457 test assertions across 34 test suites, CI via GitHub Actions
- GitHub Codespaces support for one-click demo (`make run` boots and runs all tests)

**Why it fits**: There are currently no ARM64 hypervisors listed in awesome-embedded-rust. This project demonstrates `no_std` Rust for systems programming at the highest privilege level (EL2/S-EL2), complementing the existing firmware projects which target microcontrollers.