### PR TITLE
Update tmag5273 link to active maintained driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1170,7 +1170,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 1. [ublox-cellular-rs] - Serial - Cellular driver for the full Ublox cellular serial based family
 1. [atwinc1500-rs] - SPI - A host driver for the Atwinc1500 network controller
 1. [HX711] - GPIO - An interrupt-based driver for the HX711 Load Cell Amplifier IC. no-std.
-1. [tmag5273] - Cross-platform no_std compatible i2c library for 3-axis Hall Effect sensor.
+1. [tmag5273] - I2C - TI TMAG5273 3-axis Hall-effect sensor with hardware CORDIC angle engine and typestate API - [![crates.io](https://img.shields.io/crates/v/tmag5273.svg)](https://crates.io/crates/tmag5273)
 1. [paa5100je-pwm3901] - Cross platform no-std compatible spi async library for an Optical Flow Sensor.
 
 [AD9850]: https://crates.io/crates/ad9850
@@ -1276,7 +1276,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 [ublox-cellular-rs]: https://github.com/BlackbirdHQ/ublox-cellular-rs
 [atwinc1500-rs]: https://crates.io/crates/atwinc1500
 [HX711]: https://github.com/DaneSlattery/hx711
-[tmag5273]: https://github.com/dysonltd/tmag5273
+[tmag5273]: https://github.com/coffiot/tmag5273-rs
 [paa5100je-pwm3901]: https://github.com/dysonltd/paa5100je-pwm3901
 
 ## no-std crates


### PR DESCRIPTION
## Summary

The existing `tmag5273` entry links to `https://github.com/dysonltd/tmag5273`, which now returns **404** — the repository has been deleted or made private. This PR updates the link to the actively maintained, crates.io-published driver and refreshes the description to match the format of neighboring entries (with `crates.io` badge).

## Why

- The current link is dead, so readers clicking it get a 404.
- The replacement is published on crates.io as [`tmag5273`](https://crates.io/crates/tmag5273), so it's installable via `cargo add tmag5273`.
- The new entry follows the format of nearby items (e.g. `IIS2MDC`, `VEML7700`): `[Name] - Bus - Description - [crates.io badge]`.

## Replacement crate

- Repository: https://github.com/coffiot/tmag5273-rs
- Crate: https://crates.io/crates/tmag5273
- Docs: https://docs.rs/tmag5273
- License: `MIT OR Apache-2.0`
- `no_std`, `#![forbid(unsafe_code)]`, `embedded-hal` 1.0
- Features: typestate `Unconfigured` → `Configured` API, hardware CORDIC angle engine, optional `libm` (software angle / 3-axis magnitude / axis calibration), optional `crc` (CRC-8 on I2C reads), optional `defmt`
- Test coverage: 349 unit tests (default), 450 with `libm`

## Diff

Two lines changed in `README.md` — the entry text and the link reference.

## Notes

The entry currently sits under `### WIP`. The replacement crate is published v3.6.9 and not WIP, but moving it out of that section is a separate, larger change (alphabetical reordering). Happy to do a follow-up PR if maintainers prefer it relocated.