### PR TITLE
Add RS-Key firmware project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1459,6 +1459,7 @@ There are many ways to handle panics in embedded devices, these crates provide h
 - [LuLuu](https://github.com/fu5ha/luluu): Firmware for a custom RP2040-based display controller that streams animated images from a microSD card to a small LCD display.
 - [prinThor](https://github.com/cbruiz/printhor): 3DPrinter/CNC/Engraver firmware framework powered by rust embassy for stm32 families and rp2040.
 - [🤖 hypervisor](https://github.com/willamhou/hypervisor): Bare-metal ARM64 Type-1 hypervisor in `no_std` Rust (single dependency: `fdt`). Runs at EL2, boots Linux with 4 vCPUs, virtio-blk/net, FF-A v1.1 SPMC at S-EL2. Targets QEMU virt machine (no real hardware tested yet).
+- [🤖 RS-Key](https://github.com/TheMaxMur/RS-Key): no_std FIDO2/WebAuthn + U2F security-key firmware for the RP2350, built on embassy; also implements OpenPGP, PIV and OATH.
 
 ## Old books, blogs, and training materials
 


### PR DESCRIPTION
Add RS-Key, a no_std FIDO2/OpenPGP/PIV/OATH security-key firmware for the RP2350 (embassy). https://github.com/TheMaxMur/RS-Key