### PR TITLE
Add krypteia to no-std WIP crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1407,6 +1407,7 @@ Work in progress drivers. Help the authors make these crates awesome!
 
 Work in progress crates. Help the authors make these crates awesome!
 
+- [🤖 krypteia](https://codeberg.org/cslashm/krypteia): Pure-Rust `no_std` post-quantum (ML-KEM/ML-DSA/SLH-DSA) and classical cryptography, side-channel hardened, zero-dependency. [![crates.io](https://img.shields.io/crates/v/krypteia-quantica.svg)](https://crates.io/crates/krypteia-quantica)
 - [light-cli](https://github.com/rudihorn/light-cli): a lightweight heapless cli interface [![crates.io](https://img.shields.io/crates/v/light_cli.svg)](https://crates.io/crates/light_cli)
 - [OxCC](https://github.com/jonlamb-gh/oxcc): A port of Open Source Car Control written in Rust
 - [Rubble](https://github.com/jonas-schievink/rubble): A pure-Rust embedded BLE stack [![crates.io](https://img.shields.io/crates/v/rubble.svg)](https://crates.io/crates/rubble)


### PR DESCRIPTION
This adds krypteia, a pure-Rust no_std cryptography workspace, to the no-std crates section.

What it is. Post-quantum (FIPS 203/204/205 — ML-KEM, ML-DSA, SLH-DSA) and classical (RSA, ECC, EdDSA, X25519/X448, AES, ChaCha20-Poly1305, hashes, MACs) primitives. Embedded is a first-class design goal, not an afterthought: no_std, zero runtime dependencies (std/core/alloc only), explicit RAM/stack budgets, written constant-time from the first commit.

Honest maturity status — why I'm sharing it at 0.1 rather than later. It builds and runs no_std for the embedded targets (thumbv6m / thumbv7em Cortex-M, riscv32imc / imac), and the test + side-channel suites pass — but so far validation is under emulation (qemu-user + bare-metal qemu-system), and it's fully functional on host. It has not yet run on physical silicon: the first hardware bring-up (an ESP32-C3 / RISC-V sample) is on the near-term roadmap. Side-channel countermeasures are implemented and host-verified (ctgrind / dudect); on-target power/EM measurement is future work.

So it's a 0.1, but deliberately mature enough to test and to invite early feedback. I'd rather get architecture / API / requirements input from the embedded community now, while the design can still move, than once it's set in stone — remarks on targets, memory model, feature gating, ergonomics are all very welcome.

On AI assistance. Marked 🤖 per the list convention: part of the work is AI-assisted, tracked openly via Co-Authored-By git trailers. Correctness and constant-timeness are decided by tools (NIST ACVP / Wycheproof, ctgrind, dudect), not by the model — not vibe-coded.

Pre-1.0, unaudited, structured toward a lab-class evaluation.

Docs: https://krypteia-rs.dev/
Source: https://codeberg.org/cslashm/krypteia