### PR TITLE
Add scope: serial-monitor TUI with RTT and Lua plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ specifically endorsed or reviewed for accuracy or quality by the Embedded Workin
 - [svd-generator](https://codeberg.org/weathered-steel/svd-generator) CLI tool to parse flattened device tree files, and create a SVD file. - [![crates.io](https://img.shields.io/crates/v/svd-generator.svg)](https://crates.io/crates/svd-generator)
 - [rumbac](https://github.com/akavel/rumbac) is a simple CLI flasher for *Arduino Nano 33 BLE Rev2 / Sense Rev2* boards, using the SAM-BA protocol to talk with the Arduino-provided bootloader, porting just enough of the `bossac` tool to Rust
 - [commitment-issues](https://github.com/dysonltd/commitment-issues) Compile git metadata into your binary.
+- [scope](https://github.com/matheuswhite/scope-rs) Cross-platform serial-monitor TUI with an RTT interface (via `probe-rs`), hex/`@tag` input macros, search, session recording, and Lua plugins. - [![crates.io](https://img.shields.io/crates/v/scope-monitor.svg)](https://crates.io/crates/scope-monitor)
 
 [embedded-hal-mock]: https://crates.io/crates/embedded-hal-mock
 


### PR DESCRIPTION
Adds [scope](https://github.com/matheuswhite/scope-rs) to the **Tools** section.

Scope is a cross-platform serial-monitor TUI (built with `ratatui`) that, besides serial ports, talks to embedded targets over **RTT via `probe-rs`**. It offers colored, timestamped send/receive, hex and `@tag` input macros, search, session recording, auto-reconnect, and Lua plugins. Published on crates.io as `scope-monitor`; runs on Linux, Windows and macOS.