### PR TITLE
Add Daxo OS to RTOS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ specifically endorsed or reviewed for accuracy or quality by the Embedded Workin
 - [Hubris](https://github.com/oxidecomputer/hubris) A real-time operating system built by Oxide Computer to run the Service Controller processor in the mainboards of their rack-mount servers.
 - [Zephyr](https://docs.zephyrproject.org/latest/develop/languages/rust/index.html) An embedded RTOS, written in C, with support for writing applications in Rust.
 - [Ariel OS](https://ariel-os.org/) A modular operating system written in Rust, providing multicore preemptive scheduling and application portability on top of Embassy.
+- [Daxo OS](https://github.com/daxo-developer/daxo_os) An x86_64 multitasking microkernel written in Rust, featuring hardware privilege isolation and async task execution.
 
 ### Real-time tools
 


### PR DESCRIPTION
Adding Daxo OS to the Real-time Operating System list. It is an independent x86_64 multitasking microkernel written completely from scratch in Rust, implementing low-level memory isolation and async task execution.